### PR TITLE
update copyright note on the hugo website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,7 +58,7 @@ style = "monokai"
 guessSyntax = "true"
 
 [params]
-copyright = "2021-2025. The kube-bind Authors"
+copyright = "2021-2026. The kube-bind Authors"
 footer_note = "Kubernetes and the Kubernetes logo are registered trademarks of The Linux Foundation® (TLF)."
 footer_cncf_show = false
 footer_cncf_note = "We are a Cloud Native Computing Foundation sandbox project."

--- a/config.toml
+++ b/config.toml
@@ -16,7 +16,7 @@ category = "categories"
 # set taxonomyCloud = [] to hide taxonomy clouds
 taxonomyCloud = []
 # set taxonomyPageHeader = [] to hide taxonomies on the page headers
-taxonomyPageHeader = [] 
+taxonomyPageHeader = []
 
 # Highlighting config
 pygmentsCodeFences = true
@@ -58,7 +58,7 @@ style = "monokai"
 guessSyntax = "true"
 
 [params]
-copyright = "2021-2024. The kube-bind Authors"
+copyright = "2021-2025. The kube-bind Authors"
 footer_note = "Kubernetes and the Kubernetes logo are registered trademarks of The Linux Foundation® (TLF)."
 footer_cncf_show = false
 footer_cncf_note = "We are a Cloud Native Computing Foundation sandbox project."
@@ -150,4 +150,3 @@ min = "0.75.0"
 [[module.imports]]
 ignoreImports = false
 path = "kcp"
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated copyright notice to "2021-2026. The kube-bind Authors".
  * Minor formatting cleanup in configuration (no functional or behavioral changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->