### PR TITLE
route documentation back to kube-bind.io for docs/blog

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -81,11 +81,11 @@ prism_syntax_highlighting = false
 [[menu.main]]
 name = "Documentation"
 weight = -1000
-url = "https://kbind.dev/kbind/latest"
+url = "https://docs.kube-bind.io/latest"
 [[menu.main]]
 name = "Blog"
 weight = -500
-url = "https://docs.kbind.dev/main/blog/"
+url = "https://docs.kube-bind.io/main/blog/"
 [[menu.main]]
 name = "GitHub"
 weight = -99
@@ -129,7 +129,7 @@ url = "https://groups.google.com/g/kube-bind-dev"
 name = "Helpful Links"
 [[params.links.footer.helpful.links]]
 name = "Documentation"
-url = "https://docs.kbind.dev/latest"
+url = "https://docs.kube-bind.io/latest"
 [[params.links.footer.helpful.links]]
 name = "Report a Vulnerability"
 url = "https://github.com/kbind-dev/kbind/blob/main/SECURITY.md"

--- a/data/home/data.yaml
+++ b/data/home/data.yaml
@@ -2,8 +2,8 @@ hero:
   header: "Provide and Consume Kubernetes-native Services"
   tagline: "kbind (formerly kube-bind) is a CNCF Sandbox project that aims to provide better support for service providers and consumers that reside in distinct Kubernetes clusters."
   buttons:
-    get_started: https://docs.kbind.dev/latest/setup/quickstart/
-    usage: https://docs.kbind.dev/latest/usage/
+    get_started: https://docs.kube-bind.io/latest/setup/quickstart/
+    usage: https://docs.kube-bind.io/latest/usage/
 
 cards:
   - title: "Let's design a post-operator / post-cluster technology"


### PR DESCRIPTION
We are still awaiting for another kbind.dev record, so in the meantime let's just restore it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated website and footer links to point to the new `docs.kube-bind.io` documentation site.
  * Adjusted homepage hero links so “Get started” and “Usage” now open the updated documentation URLs.
  * Fixed blog and documentation navigation links to use the latest documentation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->